### PR TITLE
Support for triggering the resize of textarea when the plugin is inialized

### DIFF
--- a/autogrow.js
+++ b/autogrow.js
@@ -9,6 +9,7 @@
                 , speed: 200 //speed of animation
                 , fixMinHeight: true //if you don't want the box to shrink below its initial size
                 , cloneClass: 'autogrowclone' //helper CSS class for clone if you need to add special rules
+                , onInitialize: false //resizes the textareas when the plugin is initialized
             }
         ;
         opts = $.isPlainObject(opts) ? opts : {context: opts ? opts : $(document)};
@@ -38,6 +39,10 @@
                 elem.data('autogrow-start-height', min); //set min height                                
             }
             elem.css('height', min);
+            
+            if (opts.onInitialize) {
+                resize.call(elem);
+            }
         });
         opts.context
             .on('keyup paste', selector, resize)
@@ -53,7 +58,7 @@
             if (oldHeight < newHeight) { //user is typing
                 this.scrollTop = 0; //try to reduce the top of the content hiding for a second
                 opts.animate ? box.stop().animate({height: newHeight}, opts.speed) : box.innerHeight(newHeight);
-            } else if (e.which == 8 || e.which == 46 || (e.ctrlKey && e.which == 88)) { //user is deleting, backspacing, or cutting
+            } else if (!e || e.which == 8 || e.which == 46 || (e.ctrlKey && e.which == 88)) { //user is deleting, backspacing, or cutting
                 if (oldHeight > minHeight) { //shrink!
                     //this cloning part is not particularly necessary. however, it helps with animation
                     //since the only way to cleanly calculate where to shrink the box to is to incrementally


### PR DESCRIPTION
A new `onInitialize` option _(defaulting to `false`)_ will call `resize()` internally when the plugin is initially called for some `selector`.

This allows a textarea with a default value that 'taller' than the height of the textarea to be resized without requiring an input from the user.

I haven't updated the README or minified version; this is just functionality I needed an thought I'd pass the idea along.

Thanks for a the plugin!
