### PR TITLE
Fix backspace issue where focus is lost from the textarea

### DIFF
--- a/autogrow.js
+++ b/autogrow.js
@@ -77,6 +77,8 @@
                     } while (newHeight === clone[0].scrollHeight);
                     newHeight++; //adding one back eliminates a wiggle on deletion 
                     clone.remove();
+                    box.focus(); // Fix issue with Chrome losing focus from the textarea.
+                    
                     //if user selects all and deletes or holds down delete til beginning
                     //user could get here and shrink whole box
                     newHeight < minHeight && (newHeight = minHeight);


### PR DESCRIPTION
On Chrome (v30) for Mac, there is an issue where if the textarea has grown, and the user then hits backspace, then their focus will be lost from the area (So if for example they hit backspace twice after a grow has occurred, the first will delete a character, but the second will trigger "Back" in the browser)

It seems to be the clone that causes this, and explicitly setting the focus to the real box again fixes the issue.
