### PR TITLE
Ensure correct target element(textarea) is used.

### DIFF
--- a/autogrow.js
+++ b/autogrow.js
@@ -49,14 +49,14 @@
         ;
     
         function resize (e){
-            var box = $(this)
+            var box = $(e.target)
                 , oldHeight = box.innerHeight()
-                , newHeight = this.scrollHeight
+                , newHeight = e.target.scrollHeight
                 , minHeight = box.data('autogrow-start-height') || 0
                 , clone
             ;
             if (oldHeight < newHeight) { //user is typing
-                this.scrollTop = 0; //try to reduce the top of the content hiding for a second
+                e.target.scrollTop = 0; //try to reduce the top of the content hiding for a second
                 if(opts.animate) {
                     box.stop().animate({height: newHeight}, {duration: opts.speed, complete: notifyGrown});
                 } else {


### PR DESCRIPTION
this in context is not always correct. In certain instances this was the jQuery document object, which means that no text area grows. Using the event target ensures that the right box is picked up and animated.